### PR TITLE
Bug fix for XmlSchemaScope: support user-defined types for complex types.

### DIFF
--- a/xmlschema-walker/src/main/java/org/apache/ws/commons/schema/walker/XmlSchemaScope.java
+++ b/xmlschema-walker/src/main/java/org/apache/ws/commons/schema/walker/XmlSchemaScope.java
@@ -305,6 +305,12 @@ final class XmlSchemaScope {
 
             walk(isMixed, complexContent);
 
+            final QName userRecognizedType =
+                getUserRecognizedType(complexType.getQName(), null);
+            if (userRecognizedType != null) {
+              typeInfo.setUserRecognizedType(userRecognizedType);
+            }
+
         } else {
             child = complexType.getParticle();
             attributes = createAttributeMap(complexType.getAttributes());


### PR DESCRIPTION
I ran into this when developing against the XML Schema Walker - user-defined types are only picked up by simple content type restrictions, not complex types.  Adding support!